### PR TITLE
Add match replacer function to the filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ vendor
 
 # Make
 .build
+
+# Vim
+*.swp

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ import (
 
 func main() {
 	f, err := filter.NewBuilder().
-		WithMask(`¯\_(:|)_/¯`).
+		SetMask(`¯\_(:|)_/¯`).
 		Build()
 	if err != nil {
 		panic(err)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ type someData struct {
 
 func main() {
 	f, err := filter.NewBuilder().
-		WithMask("*****").
+		SetMask("*****").
 		Build()
 	if err != nil {
 		panic(err)
@@ -108,7 +108,7 @@ import (
 
 func main() {
 	f, err := filter.NewBuilder().
-		WithPersonalDataProperties(`myprop`). // override all default personal data properties.
+		SetPersonalDataProperties(`myprop`). // override all default personal data properties.
 		Build()
 	if err != nil {
 		panic(err)
@@ -136,7 +136,7 @@ import (
 
 func main() {
 	f, err := filter.NewBuilder().
-		WithAdditionalPersonalDataProperties(`myprop`).
+		AddPersonalDataProperties(`myprop`).
 		Build()
 	if err != nil {
 		panic(err)
@@ -166,7 +166,7 @@ import (
 
 func main() {
 	f, err := filter.NewBuilder().
-		WithRegExp(regexp.MustCompile(`\-.*`)). // override all default regular expressions.
+		SetRegExp(regexp.MustCompile(`\-.*`)). // override all default regular expressions.
 		Build()
 	if err != nil {
 		panic(err)
@@ -195,7 +195,7 @@ import (
 
 func main() {
 	f, err := filter.NewBuilder().
-		WithAdditionalRegularExpressions(`\-.*`).
+		AddRegularExpressions(`\-.*`).
 		Build()
 	if err != nil {
 		panic(err)
@@ -212,3 +212,61 @@ func main() {
 	fmt.Println(f.RemovePersonalData(input))
 }
 ```
+- Match filter function:
+```Go
+package main
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Icenium/go-personal-data-filter/filter"
+)
+
+func main() {
+	f, err := filter.NewBuilder().
+		UseDefaultMatchFilterFunc(). // use the default match filter function to the default one - sha256 sum.
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	input := struct {
+		Personal string
+		MyProp   string
+	}{
+		Personal: "email@mail.com", // will be replaced and the result will be sha256 hash
+		MyProp:   "not-personal",   // will not be replaced
+	}
+	fmt.Printf("%#v\n", f.RemovePersonalData(input))
+}
+```
+```Go
+package main
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Icenium/go-personal-data-filter/filter"
+)
+
+func main() {
+	f, err := filter.NewBuilder().
+		SetMatchFilterFunc(func(input string) string { return input + "-replaced" }).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	input := struct {
+		Personal string
+		MyProp   string
+	}{
+		Personal: "email@mail.com", // will be replaced and the result will be email@mail.com-replaced
+		MyProp:   "not-personal",   // will not be replaced
+	}
+	fmt.Printf("%#v\n", f.RemovePersonalData(input))
+}
+```
+

--- a/filter/builder.go
+++ b/filter/builder.go
@@ -23,8 +23,8 @@ const (
 var (
 	personalDataProperties = []string{"email", "useremail", "user", "username", "userid", "accountid", "account", "password", "pass", "pwd", "ip", "ipaddress"}
 
-	errRegExpAndAdditionalRegExp   = errors.New("can't use WithAdditionalRegularExpressions and WithRegExp at the same time")
-	errPDPropsAndAdditionalPDProps = errors.New("can't use WithPersonalDataProperties and WithAdditionalPersonalDataProperties at the same time")
+	errRegExpAndAdditionalRegExp   = errors.New("can't use AddRegularExpressions and SetRegExp at the same time")
+	errPDPropsAndAdditionalPDProps = errors.New("can't use SetPersonalDataProperties and AddPersonalDataProperties at the same time")
 )
 
 // PersonalDataFilterBuilder builds personal data filter

--- a/filter/builder_test.go
+++ b/filter/builder_test.go
@@ -141,5 +141,58 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 				So(b.additionalPersonalDataProperties, ShouldHaveLength, 0)
 			})
 		})
+
+		Convey("WithDefaultMatchReplacer", func() {
+			Convey("Should set the default match replacer.", func() {
+				f, err := NewBuilder().WithDefaultMatchReplacer().Build()
+
+				So(err, ShouldBeNil)
+
+				res := f.RemovePersonalData("email@mail.com")
+
+				So(res, ShouldResemble, "3d13579f08e876d2d2d94da15ea657fb39795dd2a59e3378c9e58c4f4b0d053b")
+			})
+			Convey("Should fail if there is custom match replacer set.", func() {
+				_, err := NewBuilder().
+					WithMatchReplacer(func(string) string { return "" }).
+					WithDefaultMatchReplacer().
+					Build()
+
+				So(err, ShouldBeError, errCantAddDefaultMatchReplacer)
+			})
+			Convey("Should not add the default match replacer if there is builder error.", func() {
+				b := NewBuilder()
+				b.err = errCantAddDefaultMatchReplacer
+				b = b.WithDefaultMatchReplacer()
+				So(b.defaultMatchReplacer, ShouldBeNil)
+			})
+		})
+
+		Convey("WithMatchReplacer", func() {
+			Convey("Should set the custom match replacer.", func() {
+				expected := "expected"
+				f, err := NewBuilder().WithMatchReplacer(func(string) string { return expected }).Build()
+
+				So(err, ShouldBeNil)
+
+				res := f.RemovePersonalData("email@mail.com")
+
+				So(res, ShouldResemble, expected)
+			})
+			Convey("Should fail if the default match replacer set.", func() {
+				_, err := NewBuilder().
+					WithDefaultMatchReplacer().
+					WithMatchReplacer(func(string) string { return "" }).
+					Build()
+
+				So(err, ShouldBeError, errCantAddCustomMatchReplacer)
+			})
+			Convey("Should not add the custom match replacer if there is builder error.", func() {
+				b := NewBuilder()
+				b.err = errCantAddDefaultMatchReplacer
+				b = b.WithMatchReplacer(func(string) string { return "" })
+				So(b.matchReplacer, ShouldBeNil)
+			})
+		})
 	})
 }

--- a/filter/builder_test.go
+++ b/filter/builder_test.go
@@ -18,10 +18,10 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 		testRegExp := regexp.MustCompile(`\-.*`)
 		i := pd{MyProp: testRegExpString, Email: "not-personal"}
 
-		Convey("WithMask", func() {
+		Convey("SetMask", func() {
 			Convey("Should set the filter mask correctly.", func() {
 				mask := `¯\_(:|)_/¯`
-				f, err := NewBuilder().WithMask(mask).Build()
+				f, err := NewBuilder().SetMask(mask).Build()
 
 				So(err, ShouldBeNil)
 
@@ -33,14 +33,14 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 				mask := `¯\_(:|)_/¯`
 				b := NewBuilder()
 				b.err = errPDPropsAndAdditionalPDProps
-				b = b.WithMask(mask)
+				b = b.SetMask(mask)
 				So(b.mask, ShouldEqual, "")
 			})
 		})
 
-		Convey("WithRegExp", func() {
+		Convey("SetRegExp", func() {
 			Convey("Should use the provided regular expression.", func() {
-				f, err := NewBuilder().WithRegExp(testRegExp).Build()
+				f, err := NewBuilder().SetRegExp(testRegExp).Build()
 
 				So(err, ShouldBeNil)
 
@@ -50,8 +50,8 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 			})
 			Convey("Should fail the build if it's used after WithAdditionalRegularExpression.", func() {
 				_, err := NewBuilder().
-					WithAdditionalRegularExpressions("some").
-					WithRegExp(testRegExp).
+					AddRegularExpressions("some").
+					SetRegExp(testRegExp).
 					Build()
 
 				So(err, ShouldBeError, errRegExpAndAdditionalRegExp)
@@ -59,14 +59,14 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 			Convey("Should not set reg exp if there is builder error.", func() {
 				b := NewBuilder()
 				b.err = errPDPropsAndAdditionalPDProps
-				b = b.WithRegExp(testRegExp)
+				b = b.SetRegExp(testRegExp)
 				So(b.regExp, ShouldBeNil)
 			})
 		})
 
-		Convey("WithAdditionalRegularExpression", func() {
+		Convey("AddRegularExpressions", func() {
 			Convey("Should use the provided regular expression.", func() {
-				f, err := NewBuilder().WithAdditionalRegularExpressions(testRegExp.String()).Build()
+				f, err := NewBuilder().AddRegularExpressions(testRegExp.String()).Build()
 
 				So(err, ShouldBeNil)
 
@@ -76,8 +76,8 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 			})
 			Convey("Should fail the build if it's used after WithRegExp.", func() {
 				_, err := NewBuilder().
-					WithRegExp(testRegExp).
-					WithAdditionalRegularExpressions("some").
+					SetRegExp(testRegExp).
+					AddRegularExpressions("some").
 					Build()
 
 				So(err, ShouldBeError, errRegExpAndAdditionalRegExp)
@@ -85,14 +85,14 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 			Convey("Should not add reg exp if there is builder error.", func() {
 				b := NewBuilder()
 				b.err = errPDPropsAndAdditionalPDProps
-				b = b.WithAdditionalRegularExpressions("some")
+				b = b.AddRegularExpressions("some")
 				So(b.additionalRegExps, ShouldHaveLength, 0)
 			})
 		})
 
-		Convey("WithPersonalDataProperties", func() {
+		Convey("SetPersonalDataProperties", func() {
 			Convey("Should use the provided personal data properties.", func() {
-				f, err := NewBuilder().WithPersonalDataProperties("myprop").Build()
+				f, err := NewBuilder().SetPersonalDataProperties("myprop").Build()
 
 				So(err, ShouldBeNil)
 
@@ -102,8 +102,8 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 			})
 			Convey("Should fail the build if it's used after WithAdditionalPersonalDataProperties.", func() {
 				_, err := NewBuilder().
-					WithAdditionalPersonalDataProperties("some").
-					WithPersonalDataProperties("prop").
+					AddPersonalDataProperties("some").
+					SetPersonalDataProperties("prop").
 					Build()
 
 				So(err, ShouldBeError, errPDPropsAndAdditionalPDProps)
@@ -111,14 +111,14 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 			Convey("Should not set personal data properties if there is builder error.", func() {
 				b := NewBuilder()
 				b.err = errPDPropsAndAdditionalPDProps
-				b = b.WithPersonalDataProperties("some")
+				b = b.SetPersonalDataProperties("some")
 				So(b.personalDataProperties, ShouldHaveLength, 0)
 			})
 		})
 
-		Convey("WithAdditionalPersonalDataProperties", func() {
+		Convey("AddPersonalDataProperties", func() {
 			Convey("Should use the provided personal data properties.", func() {
-				f, err := NewBuilder().WithAdditionalPersonalDataProperties("myprop").Build()
+				f, err := NewBuilder().AddPersonalDataProperties("myprop").Build()
 
 				So(err, ShouldBeNil)
 
@@ -128,8 +128,8 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 			})
 			Convey("Should fail the build if it's used after WithPersonalDataProperties.", func() {
 				_, err := NewBuilder().
-					WithPersonalDataProperties("prop").
-					WithAdditionalPersonalDataProperties("some").
+					SetPersonalDataProperties("prop").
+					AddPersonalDataProperties("some").
 					Build()
 
 				So(err, ShouldBeError, errPDPropsAndAdditionalPDProps)
@@ -137,14 +137,14 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 			Convey("Should not add personal data properties if there is builder error.", func() {
 				b := NewBuilder()
 				b.err = errPDPropsAndAdditionalPDProps
-				b = b.WithAdditionalPersonalDataProperties("some")
+				b = b.AddPersonalDataProperties("some")
 				So(b.additionalPersonalDataProperties, ShouldHaveLength, 0)
 			})
 		})
 
-		Convey("WithDefaultMatchReplacer", func() {
+		Convey("UseDefaultMatchFilterFunc", func() {
 			Convey("Should set the default match replacer.", func() {
-				f, err := NewBuilder().WithDefaultMatchReplacer().Build()
+				f, err := NewBuilder().UseDefaultMatchFilterFunc().Build()
 
 				So(err, ShouldBeNil)
 
@@ -152,26 +152,12 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 
 				So(res, ShouldResemble, "3d13579f08e876d2d2d94da15ea657fb39795dd2a59e3378c9e58c4f4b0d053b")
 			})
-			Convey("Should fail if there is custom match replacer set.", func() {
-				_, err := NewBuilder().
-					WithMatchReplacer(func(string) string { return "" }).
-					WithDefaultMatchReplacer().
-					Build()
-
-				So(err, ShouldBeError, errCantAddDefaultMatchReplacer)
-			})
-			Convey("Should not add the default match replacer if there is builder error.", func() {
-				b := NewBuilder()
-				b.err = errCantAddDefaultMatchReplacer
-				b = b.WithDefaultMatchReplacer()
-				So(b.defaultMatchReplacer, ShouldBeNil)
-			})
 		})
 
-		Convey("WithMatchReplacer", func() {
+		Convey("SetMatchFilterFunc", func() {
 			Convey("Should set the custom match replacer.", func() {
 				expected := "expected"
-				f, err := NewBuilder().WithMatchReplacer(func(string) string { return expected }).Build()
+				f, err := NewBuilder().SetMatchFilterFunc(func(string) string { return expected }).Build()
 
 				So(err, ShouldBeNil)
 
@@ -179,19 +165,11 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 
 				So(res, ShouldResemble, expected)
 			})
-			Convey("Should fail if the default match replacer set.", func() {
-				_, err := NewBuilder().
-					WithDefaultMatchReplacer().
-					WithMatchReplacer(func(string) string { return "" }).
-					Build()
-
-				So(err, ShouldBeError, errCantAddCustomMatchReplacer)
-			})
 			Convey("Should not add the custom match replacer if there is builder error.", func() {
 				b := NewBuilder()
-				b.err = errCantAddDefaultMatchReplacer
-				b = b.WithMatchReplacer(func(string) string { return "" })
-				So(b.matchReplacer, ShouldBeNil)
+				b.err = errPDPropsAndAdditionalPDProps
+				b = b.SetMatchFilterFunc(func(string) string { return "" })
+				So(b.matchFilterFunc, ShouldBeNil)
 			})
 		})
 	})

--- a/filter/builder_test.go
+++ b/filter/builder_test.go
@@ -48,7 +48,7 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 
 				So(res, ShouldResemble, pd{MyProp: "test", Email: ""})
 			})
-			Convey("Should fail the build if it's used after WithAdditionalRegularExpression.", func() {
+			Convey("Should fail the build if it's used after AddRegularExpressions.", func() {
 				_, err := NewBuilder().
 					AddRegularExpressions("some").
 					SetRegExp(testRegExp).
@@ -74,7 +74,7 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 
 				So(res, ShouldResemble, pd{MyProp: "test", Email: ""})
 			})
-			Convey("Should fail the build if it's used after WithRegExp.", func() {
+			Convey("Should fail the build if it's used after SetRegExp.", func() {
 				_, err := NewBuilder().
 					SetRegExp(testRegExp).
 					AddRegularExpressions("some").
@@ -100,7 +100,7 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 
 				So(res, ShouldResemble, pd{MyProp: "", Email: "not-personal"})
 			})
-			Convey("Should fail the build if it's used after WithAdditionalPersonalDataProperties.", func() {
+			Convey("Should fail the build if it's used after AddPersonalDataProperties.", func() {
 				_, err := NewBuilder().
 					AddPersonalDataProperties("some").
 					SetPersonalDataProperties("prop").
@@ -126,7 +126,7 @@ func TestPersonalDataFilterBuilder(t *testing.T) {
 
 				So(res, ShouldResemble, pd{MyProp: "", Email: ""})
 			})
-			Convey("Should fail the build if it's used after WithPersonalDataProperties.", func() {
+			Convey("Should fail the build if it's used after SetPersonalDataProperties.", func() {
 				_, err := NewBuilder().
 					SetPersonalDataProperties("prop").
 					AddPersonalDataProperties("some").

--- a/filter/example_configuration_test.go
+++ b/filter/example_configuration_test.go
@@ -9,7 +9,7 @@ import (
 
 func ExampleNewBuilder() {
 	f, err := filter.NewBuilder().
-		WithMask(`¯\_(:|)_/¯`).
+		SetMask(`¯\_(:|)_/¯`).
 		Build()
 	if err != nil {
 		panic(err)
@@ -20,9 +20,9 @@ func ExampleNewBuilder() {
 	// ¯\_(:|)_/¯
 }
 
-func ExamplePersonalDataFilterBuilder_WithPersonalDataProperties() {
+func ExamplePersonalDataFilterBuilder_SetPersonalDataProperties() {
 	f, err := filter.NewBuilder().
-		WithPersonalDataProperties(`myprop`).
+		SetPersonalDataProperties(`myprop`).
 		Build()
 	if err != nil {
 		panic(err)
@@ -41,9 +41,9 @@ func ExamplePersonalDataFilterBuilder_WithPersonalDataProperties() {
 	// struct { Email string; MyProp string }{Email:"not-personal", MyProp:""}
 }
 
-func ExamplePersonalDataFilterBuilder_WithAdditionalPersonalDataProperties() {
+func ExamplePersonalDataFilterBuilder_AddPersonalDataProperties() {
 	f, err := filter.NewBuilder().
-		WithAdditionalPersonalDataProperties(`myprop`).
+		AddPersonalDataProperties(`myprop`).
 		Build()
 	if err != nil {
 		panic(err)
@@ -61,9 +61,9 @@ func ExamplePersonalDataFilterBuilder_WithAdditionalPersonalDataProperties() {
 	// struct { Email string; MyProp string }{Email:"", MyProp:""}
 }
 
-func ExamplePersonalDataFilterBuilder_WithRegExp() {
+func ExamplePersonalDataFilterBuilder_SetRegExp() {
 	f, err := filter.NewBuilder().
-		WithRegExp(regexp.MustCompile(`\-.*`)). // override all default regular expressions.
+		SetRegExp(regexp.MustCompile(`\-.*`)). // override all default regular expressions.
 		Build()
 	if err != nil {
 		panic(err)
@@ -81,9 +81,9 @@ func ExamplePersonalDataFilterBuilder_WithRegExp() {
 	// struct { Personal string; MyProp string }{Personal:"some@mail.com", MyProp:"not"}
 }
 
-func ExamplePersonalDataFilterBuilder_WithAdditionalRegularExpressions() {
+func ExamplePersonalDataFilterBuilder_AddRegularExpressions() {
 	f, err := filter.NewBuilder().
-		WithAdditionalRegularExpressions(`\-.*`).
+		AddRegularExpressions(`\-.*`).
 		Build()
 	if err != nil {
 		panic(err)
@@ -101,9 +101,9 @@ func ExamplePersonalDataFilterBuilder_WithAdditionalRegularExpressions() {
 	// struct { Personal string; MyProp string }{Personal:"", MyProp:"not"}
 }
 
-func ExamplePersonalDataFilterBuilder_WithDefaultMatchReplacer() {
+func ExamplePersonalDataFilterBuilder_UseDefaultMatchFilterFunc() {
 	f, err := filter.NewBuilder().
-		WithDefaultMatchReplacer().
+		UseDefaultMatchFilterFunc().
 		Build()
 	if err != nil {
 		panic(err)
@@ -121,9 +121,9 @@ func ExamplePersonalDataFilterBuilder_WithDefaultMatchReplacer() {
 	// struct { Personal string; MyProp string }{Personal:"3d13579f08e876d2d2d94da15ea657fb39795dd2a59e3378c9e58c4f4b0d053b", MyProp:"not-personal"}
 }
 
-func ExamplePersonalDataFilterBuilder_WithMatchReplacer() {
+func ExamplePersonalDataFilterBuilder_SetMatchFilterFunc() {
 	f, err := filter.NewBuilder().
-		WithMatchReplacer(func(input string) string { return input + "-replaced" }).
+		SetMatchFilterFunc(func(input string) string { return input + "-replaced" }).
 		Build()
 	if err != nil {
 		panic(err)

--- a/filter/example_configuration_test.go
+++ b/filter/example_configuration_test.go
@@ -100,3 +100,43 @@ func ExamplePersonalDataFilterBuilder_WithAdditionalRegularExpressions() {
 	// Output:
 	// struct { Personal string; MyProp string }{Personal:"", MyProp:"not"}
 }
+
+func ExamplePersonalDataFilterBuilder_WithDefaultMatchReplacer() {
+	f, err := filter.NewBuilder().
+		WithDefaultMatchReplacer().
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	input := struct {
+		Personal string
+		MyProp   string
+	}{
+		Personal: "email@mail.com", // will be replaced and the result will be sha256 hash
+		MyProp:   "not-personal",   // will not be replaced
+	}
+	fmt.Printf("%#v\n", f.RemovePersonalData(input))
+	// Output:
+	// struct { Personal string; MyProp string }{Personal:"3d13579f08e876d2d2d94da15ea657fb39795dd2a59e3378c9e58c4f4b0d053b", MyProp:"not-personal"}
+}
+
+func ExamplePersonalDataFilterBuilder_WithMatchReplacer() {
+	f, err := filter.NewBuilder().
+		WithMatchReplacer(func(input string) string { return input + "-replaced" }).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	input := struct {
+		Personal string
+		MyProp   string
+	}{
+		Personal: "email@mail.com", // will be replaced and the result will be email@mail.com-replaced
+		MyProp:   "not-personal",   // will not be replaced
+	}
+	fmt.Printf("%#v\n", f.RemovePersonalData(input))
+	// Output:
+	// struct { Personal string; MyProp string }{Personal:"email@mail.com-replaced", MyProp:"not-personal"}
+}

--- a/filter/example_package_test.go
+++ b/filter/example_package_test.go
@@ -17,7 +17,7 @@ type someData struct {
 
 func Example() {
 	f, err := filter.NewBuilder().
-		WithMask("*****").
+		SetMask("*****").
 		Build()
 	if err != nil {
 		panic(err)

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -14,6 +14,7 @@ const (
 
 type personalDataFilter struct {
 	mask                   string
+	matchReplacer          *MatchReplacer
 	personalDataRegExp     *regexp.Regexp
 	personalDataProperties []string
 }
@@ -55,7 +56,13 @@ func (filter *personalDataFilter) RemovePersonalData(input interface{}) interfac
 }
 
 func (filter *personalDataFilter) handleString(input interface{}) interface{} {
-	filtered := filter.personalDataRegExp.ReplaceAllString(input.(string), filter.mask)
+	var filtered string
+	if filter.matchReplacer != nil {
+		filtered = filter.personalDataRegExp.ReplaceAllStringFunc(input.(string), *filter.matchReplacer)
+	} else {
+		filtered = filter.personalDataRegExp.ReplaceAllString(input.(string), filter.mask)
+	}
+
 	return filtered
 }
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -14,7 +14,7 @@ const (
 
 type personalDataFilter struct {
 	mask                   string
-	matchReplacer          *MatchReplacer
+	matchFilterFunc        *MatchFilterFunc
 	personalDataRegExp     *regexp.Regexp
 	personalDataProperties []string
 }
@@ -57,8 +57,8 @@ func (filter *personalDataFilter) RemovePersonalData(input interface{}) interfac
 
 func (filter *personalDataFilter) handleString(input interface{}) interface{} {
 	var filtered string
-	if filter.matchReplacer != nil {
-		filtered = filter.personalDataRegExp.ReplaceAllStringFunc(input.(string), *filter.matchReplacer)
+	if filter.matchFilterFunc != nil {
+		filtered = filter.personalDataRegExp.ReplaceAllStringFunc(input.(string), *filter.matchFilterFunc)
 	} else {
 		filtered = filter.personalDataRegExp.ReplaceAllString(input.(string), filter.mask)
 	}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -93,7 +93,7 @@ func TestPersonalDataFilter(t *testing.T) {
 
 	Convey("RemovePersonalData", t, func() {
 		filter, err := NewBuilder().
-			WithMask(filteredString).
+			SetMask(filteredString).
 			Build()
 		if err != nil {
 			panic(err)
@@ -179,7 +179,7 @@ func TestPersonalDataFilter(t *testing.T) {
 					createTestCaseWithReplacer(getHash, "text%stext", ipV6),
 				}
 
-				hashFilter, _ := NewBuilder().WithDefaultMatchReplacer().Build()
+				hashFilter, _ := NewBuilder().UseDefaultMatchFilterFunc().Build()
 				checkTestCases(hashFilter, testCases)
 			})
 		})
@@ -396,7 +396,7 @@ func createTestCase(template string, args ...interface{}) testCase {
 	}
 }
 
-func createTestCaseWithReplacer(replacer MatchReplacer, template string, args ...interface{}) testCase {
+func createTestCaseWithReplacer(replacer MatchFilterFunc, template string, args ...interface{}) testCase {
 	expectedArgs := make([]interface{}, len(args))
 	for i := range args {
 		expectedArgs[i] = replacer(args[i].(string))

--- a/filter/types.go
+++ b/filter/types.go
@@ -7,6 +7,10 @@ type PersonalDataFilter interface {
 	RemovePersonalData(input interface{}) interface{}
 }
 
+// MatchReplacer is function which will be used to replace each match found by some
+// of the registered regular expressions.
+type MatchReplacer func(match string) (replaced string)
+
 type filterTagConfig struct {
 	NoFilter bool
 }

--- a/filter/types.go
+++ b/filter/types.go
@@ -7,9 +7,9 @@ type PersonalDataFilter interface {
 	RemovePersonalData(input interface{}) interface{}
 }
 
-// MatchReplacer is function which will be used to replace each match found by some
+// MatchFilterFunc is function which will be used to replace each match found by some
 // of the registered regular expressions.
-type MatchReplacer func(match string) (replaced string)
+type MatchFilterFunc func(match string) (replaced string)
 
 type filterTagConfig struct {
 	NoFilter bool


### PR DESCRIPTION
The match replacer is function which receives each match from the personal data regular expression and returns the value which will be set in the filtered struct.

The default match replacer is sha256 sum.